### PR TITLE
`add_section` use case details

### DIFF
--- a/resource-server/src/main/java/com/elearning/course/application/dto/CourseSectionDTO.java
+++ b/resource-server/src/main/java/com/elearning/course/application/dto/CourseSectionDTO.java
@@ -3,6 +3,7 @@ package com.elearning.course.application.dto;
 import com.elearning.course.domain.CourseSection;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 
 import java.util.Set;
 
@@ -10,6 +11,7 @@ public record CourseSectionDTO(
         @NotBlank(message = "Section title is required")
         String title,
         @Valid
+        @NotEmpty(message = "At least one lesson is required")
         Set<LessonDTO> lessons
 ) {
 

--- a/resource-server/src/main/java/com/elearning/course/application/dto/LessonDTO.java
+++ b/resource-server/src/main/java/com/elearning/course/application/dto/LessonDTO.java
@@ -10,9 +10,7 @@ public record LessonDTO(
         String title,
         @NotNull(message = "Lesson description is required")
         Lesson.Type type,
-        @NotBlank(message = "Lesson link is required")
         String link,
-        @NotNull(message = "Lesson quiz is required")
         Long quiz
 ) {
     public Lesson toLesson() {

--- a/resource-server/src/main/java/com/elearning/course/domain/Lesson.java
+++ b/resource-server/src/main/java/com/elearning/course/domain/Lesson.java
@@ -1,6 +1,8 @@
 package com.elearning.course.domain;
 
+import com.elearning.common.exception.InputInvalidException;
 import lombok.Getter;
+import org.apache.commons.lang3.Validate;
 import org.springframework.data.annotation.*;
 import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.util.Assert;
@@ -48,16 +50,20 @@ public class Lesson {
             case VIDEO:
             case TEXT:
                 if (link == null || link.isEmpty()) {
-                    throw new IllegalArgumentException("Link must not be empty for VIDEO or TEXT lesson.");
+                    throw new InputInvalidException("Link must not be empty for VIDEO or TEXT lesson.");
+                }
+                // validate link format
+                if (!link.startsWith("http://") && !link.startsWith("https://")) {
+                    throw new InputInvalidException("Link must is a valid URL.");
                 }
                 break;
             case QUIZ:
                 if (quiz == null) {
-                    throw new IllegalArgumentException("Quiz ID must not be null for QUIZ lesson.");
+                    throw new InputInvalidException("Quiz ID must not be null for QUIZ lesson.");
                 }
                 break;
             default:
-                throw new IllegalArgumentException("Unsupported lesson type.");
+                throw new InputInvalidException("Unsupported lesson type.");
         }
     }
 

--- a/resource-server/src/main/java/com/elearning/course/web/CourseController.java
+++ b/resource-server/src/main/java/com/elearning/course/web/CourseController.java
@@ -95,7 +95,7 @@ public class CourseController {
     public ResponseEntity<Course> addSection(@PathVariable Long courseId,
                                              @RequestBody @Valid CourseSectionDTO courseSectionDTO) {
         Course updatedCourse = courseService.addSection(courseId, courseSectionDTO);
-        return ResponseEntity.ok(updatedCourse);
+        return ResponseEntity.created(URI.create("/courses/" + courseId)).body(updatedCourse);
     }
 
 

--- a/resource-server/src/main/resources/db/migration/V1__Initial_schema.sql
+++ b/resource-server/src/main/resources/db/migration/V1__Initial_schema.sql
@@ -46,7 +46,8 @@ create table lesson
     id             bigserial    not null,
     title          varchar(255) not null,
     type           varchar(255) not null,
-    link           varchar(255) not null,
+    link           varchar(255),
+    quiz           bigint,
     course_section bigint       not null references course_section (id) on DELETE cascade,
     constraint fk_lesson primary key (id)
 );

--- a/resource-server/src/test/java/com/elearning/course/domain/CourseJdbcTests.java
+++ b/resource-server/src/test/java/com/elearning/course/domain/CourseJdbcTests.java
@@ -55,6 +55,23 @@ public class CourseJdbcTests {
     }
 
     @Test
+    void testSaveCourseWithSections() {
+        // Tạo một course với các sections
+        CourseSection section1 = new CourseSection("Introduction");
+        section1.addLesson(new Lesson("What is Java?", Lesson.Type.TEXT, "https://example.com/lesson1", null));
+        section1.addLesson(new Lesson("What is Java 2?", Lesson.Type.QUIZ, null, 1L));
+        course.addSection(section1);
+
+        // Lưu course vào database
+        Course savedCourse = courseRepository.save(course);
+
+        // Kiểm tra xem course và các sections có được lưu không
+        assertNotNull(savedCourse.getId());
+        assertEquals(1, savedCourse.getSections().size());
+        assertEquals(2, savedCourse.getSections().iterator().next().getLessons().size());
+    }
+
+    @Test
     public void testFindById() {
         // Lưu course vào database trước
         Course savedCourse = courseRepository.save(course);

--- a/resource-server/src/test/java/com/elearning/course/domain/CourseTests.java
+++ b/resource-server/src/test/java/com/elearning/course/domain/CourseTests.java
@@ -223,4 +223,47 @@ public class CourseTests {
         assertThrows(NullPointerException.class, () -> course.applyDiscount(null, discountCode));
     }
 
+    @Test
+    void addSection_ValidSection_AddsSection() {
+        Course course = new Course("Title", "Description", "ThumbnailUrl", new HashSet<>(), Language.ENGLISH, new HashSet<>(), new HashSet<>(), "Teacher");
+        CourseSection section = new CourseSection("SectionTitle");
+        section.addLesson(new Lesson("LessonTitle", Lesson.Type.TEXT, "https://www.example.com", null));
+        course.addSection(section);
+        assertTrue(course.getSections().contains(section));
+    }
+
+    @Test
+    void addSection_NullSection_ThrowsException() {
+        Course course = new Course("Title", "Description", "ThumbnailUrl", new HashSet<>(), Language.ENGLISH, new HashSet<>(), new HashSet<>(), "Teacher");
+        assertThrows(NullPointerException.class, () -> course.addSection(null));
+    }
+
+    @Test
+    void addSection_SectionWithSameTitle_ThrowsException() {
+        Course course = new Course("Title", "Description", "ThumbnailUrl", new HashSet<>(), Language.ENGLISH, new HashSet<>(), new HashSet<>(), "Teacher");
+        CourseSection section = new CourseSection("SectionTitle");
+        section.addLesson(new Lesson("LessonTitle", Lesson.Type.TEXT, "https://www.example.com", null));
+        course.addSection(section);
+
+        // Tạo một section khác có cùng title với section đã thêm vào course
+        CourseSection duplicateSection = new CourseSection("SectionTitle");
+        assertThrows(InputInvalidException.class, () -> course.addSection(duplicateSection));
+    }
+
+    @Test
+    void addSection_SectionWithoutLessons_ThrowsException() {
+        Course course = new Course("Title", "Description", "ThumbnailUrl", new HashSet<>(), Language.ENGLISH, new HashSet<>(), new HashSet<>(), "Teacher");
+        CourseSection section = new CourseSection("SectionTitle");
+        assertThrows(InputInvalidException.class, () -> course.addSection(section));
+    }
+
+    @Test
+    void addSection_PublishedCourse_ThrowsException() {
+        Course course = spy(new Course("Title", "Description", "ThumbnailUrl", new HashSet<>(), Language.ENGLISH, new HashSet<>(), new HashSet<>(), "Teacher"));
+        when(course.canEdit()).thenReturn(false); // Giả lập khóa học đã publish
+
+        CourseSection section = new CourseSection("SectionTitle");
+        assertThrows(InputInvalidException.class, () -> course.addSection(section));
+    }
+
 }


### PR DESCRIPTION
> [!NOTE]
> 1. cập nhật CourseJdbcTests: Kiểm tra trường hợp lưu đối tượng Course có cả Section và Lesson, Kiểm tra xem table `lesson` và table `section` có lưu dược khi `addSection()` không!
> 2. bean validation cho DTO cho use case này
> 3. Cập nhật exception được throws ra của `Lesson-validateLinkOrQuiz`
> 4. Cập nhật lại schema


**Test Result**

| Class | Method | Status|
|--------|--------|-----|
| CourseTests | addSection_ValidSection_AddsSection | Pass|
|  | addSection_NullSection_ThrowsException |Pass|
|  | addSection_SectionWithSameTitle_ThrowsException |Pass|
|  | addSection_SectionWithoutLessons_ThrowsException |Pass|
|  | addSection_PublishedCourse_ThrowsException | Pass|
|CourseJdbcTests|testSaveCourseWithSections|Pass|
|CourseServiceTests|addCourseSection_ShouldAddCourseSection|Pass|
||testSaveCourseWithSections|Pass|
||addCourseSection_ShouldThrowException_WhenCourseNotFound|Pass|
||addCourseSection_ShouldThrowException_WhenLessonIsInvalid|Pass|
||addCourseSection_ShouldThrowException_WhenLessonIsInvalidQuizType|Pass|
||addCourseSection_ShouldThrowException_WhenLessonIsInvalidTextOrVideoType|Pass|
|ResourceServerApplicationTests|testAddSectionToCourse_Successful|Pass|
||testAddSectionToCourse_Unauthorized|Pass|
||testAddSectionToCourse_Forbidden|Pass|
